### PR TITLE
Fix loading variable before normal html comment

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,8 @@ Change History
 0.4 - Unreleased
 ----------------
 
-- In-progress...
+- Fix loading variable before normal html comment
+[huubbouma]
 
 0.3 - 2014-07-19
 ----------------

--- a/codekitlang/compiler.py
+++ b/codekitlang/compiler.py
@@ -25,7 +25,7 @@ SPECIAL_COMMENT_RE = re.compile(
     r'(?P<wrapper><!--\s*(?:'
     r'@(?:(?i)(?:import|include))\s+(?P<filenames>.*?)'
     r'|'
-    r'[@$](?P<variable>[a-zA-Z][^\s:=]*)\s*(?:[\s:=]\s*(?P<value>.*?))?'
+    r'[@$](?P<variable>[a-zA-Z][^\s:=]*?)\s*(?:[\s:=]\s*(?P<value>.*?))?'
     r')-->)',
     re.DOTALL | re.LOCALE | re.MULTILINE | re.UNICODE
 )

--- a/codekitlang/tests/test_compiler.py
+++ b/codekitlang/tests/test_compiler.py
@@ -161,7 +161,10 @@ class GetNewSignatureTestCase(unittest.TestCase):
 
     def test(self):
         fn = os.path.join(self.tempdir, 'testfile')
-        touch = lambda x: open(fn, 'wb').write(x)
+
+        def touch(x):
+            open(fn, 'wb').write(x)
+
         touch('')
         ret1 = self.func(fn)
         self.assertIsNotNone(ret1)
@@ -245,6 +248,15 @@ class ParseStrTestCase(unittest.TestCase):
         self.assertEqual([Fragment(0, 1, 1, 'NOOP', 'pre '),
                           Fragment(4, 1, 5, 'LOAD', 'VAR2'),
                           Fragment(18, 1, 19, 'NOOP', ' post')], ret)
+
+    def test_load_3(self):
+        from ..compiler import Fragment
+        source = '<!--$cssPath-->main.css">' \
+                 '<!--[if lt IE 7]><p>NOOOO</p><![endif]-->'
+        remainder = 'main.css"><!--[if lt IE 7]><p>NOOOO</p><![endif]-->'
+        ret = self.func(source)
+        self.assertEqual([Fragment(0, 1, 1, 'LOAD', 'cssPath'),
+                          Fragment(15, 1, 16, 'NOOP', remainder)], ret)
 
     def test_stor_1(self):
         from ..compiler import Fragment

--- a/setup.py
+++ b/setup.py
@@ -43,9 +43,9 @@ setup(
     zip_safe=False,
     install_requires=('setuptools',),
     tests_require=('pytest-cov', 'pytest-pep8', 'pytest-flakes', 'mock',
-                   'testfixtures'),
+                   'testfixtures', 'pytest-cache', ),
     cmdclass={'test': PyTest},
-    test_suite = 'codekitlang.tests',
+    test_suite='codekitlang.tests',
     entry_points={
         'console_scripts': (
             'pykitlangc = codekitlang.command:main',


### PR DESCRIPTION
Hi there,

There is a problem in the current compiler for the snippet of kit code:

```
    <link rel="stylesheet" href="<!--$cssPath-->main.css">
</head>
<body>
    <!--[if lt IE 7]>
        <p class="browsehappy">please don't</p>
    <![endif]-->
```

In this case the cssPath is not loaded but stored because of the eager loading of the variable regex:

```
(?P<variable>[a-zA-Z][^\s:=]*)
```

in combination with the next html comment. The variable is matched all the way until the endif.
The fix is simple: add a questionmark so the variable matching is non eager

I added a unittest (and fixed some unit test issues I ran into, like some pep8 and a missing pytest-cache egg)

Hope you will merge my pull request.

Cheers, Huub
